### PR TITLE
Fix invalid value for `id-token` GHA permission

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
 
     permissions:
       contents: write
-      id-token: read
+      id-token: write
       packages: write
 
     steps:


### PR DESCRIPTION
Apparently `read` is not a thing, oops!