### PR TITLE
Remove superfluous permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
-      id-token: write
       packages: write
 
     steps:


### PR DESCRIPTION
Turns out the reason the overarching feature metadata package couldn't be written to was that there was a package by the same name from a previous attempt of building devcontainer features in a since deleted repository that still existed!