### PR TITLE
Bundle `rcrc` with personal setup feature

### DIFF
--- a/src/personal-setup/NOTES.md
+++ b/src/personal-setup/NOTES.md
@@ -12,7 +12,12 @@ I've previously (ab)used the _Dev Containers_ extension's built in dotfiles supp
 This feature:
 - Installs a set of packages in the container (including `rcm` for dotfiles management)
 - Mounts my dotfiles repositories into the container
-- Installs the dotfiles (with appropriate tags)
+- Copies in an `rcrc` for dotfiles configuration, including:
+  - setting the correct tags and dotfiles mount locations
+  - avoiding setting up git config (as VS Code will copy it into the container anyway with
+    modifications, which would modify our canonical dotfiles version with transient,
+    container-specific setup)
+- Installs the dotfiles
 
 This feature is intended to be configured as part of my personal user settings as a default feature
 for all devcontainers (through `dev.containers.defaultFeatures`). It's obviously specific to me,

--- a/src/personal-setup/README.md
+++ b/src/personal-setup/README.md
@@ -7,7 +7,7 @@ Sets up my desired software and configuration for any devcontainer environment.
 
 ```json
 "features": {
-    "ghcr.io/csutter/devcontainer-features/personal-setup:1": {}
+    "ghcr.io/csutter/devcontainer-features/personal-setup:2": {}
 }
 ```
 
@@ -27,7 +27,12 @@ I've previously (ab)used the _Dev Containers_ extension's built in dotfiles supp
 This feature:
 - Installs a set of packages in the container (including `rcm` for dotfiles management)
 - Mounts my dotfiles repositories into the container
-- Installs the dotfiles (with appropriate tags)
+- Copies in an `rcrc` for dotfiles configuration, including:
+  - setting the correct tags and dotfiles mount locations
+  - avoiding setting up git config (as VS Code will copy it into the container anyway with
+    modifications, which would modify our canonical dotfiles version with transient,
+    container-specific setup)
+- Installs the dotfiles
 
 This feature is intended to be configured as part of my personal user settings as a default feature
 for all devcontainers (through `dev.containers.defaultFeatures`). It's obviously specific to me,

--- a/src/personal-setup/devcontainer-feature.json
+++ b/src/personal-setup/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "personal-setup",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "name": "Personal Setup",
   "description": "Sets up my desired software and configuration for any devcontainer environment.",
   "mounts": [
@@ -16,7 +16,7 @@
     }
   ],
   "containerEnv": {
-    "RCRC": "/mnt/dotfiles/tag-devcontainer/rcrc",
+    "RCRC": "/etc/rcrc",
     "_IS_DEVCONTAINER": "true"
   },
   "postCreateCommand": "rcup -vf"

--- a/src/personal-setup/install.sh
+++ b/src/personal-setup/install.sh
@@ -23,3 +23,5 @@ case "$ID" in
         exit 1
         ;;
 esac
+
+cp rcrc /etc/rcrc

--- a/src/personal-setup/rcrc
+++ b/src/personal-setup/rcrc
@@ -1,0 +1,3 @@
+EXCLUDES="*.md config/git/config"
+TAGS="devcontainer"
+DOTFILES_DIRS="/mnt/dotfiles /mnt/dotfiles-private"

--- a/test/personal-setup/test.sh
+++ b/test/personal-setup/test.sh
@@ -10,6 +10,7 @@ check "tree is available"       bash -c "which tree"
 check "ssh is available"        bash -c "which ssh"
 # Use a dotfile that should _always_ be present on any system
 check "dotfiles are installed"  bash -c "test -f $HOME/.config/fish/config.fish"
+check "rcrc is present"         bash -c "test -f /etc/rcrc"
 check "_IS_DEVCONTAINER is set" bash -c "test \"\$_IS_DEVCONTAINER\" = \"true\""
 
 reportResults


### PR DESCRIPTION
This helps me get rid of the slightly confusing tag structure in my dotfiles by moving `rcrc` files out of being managed by RCM.